### PR TITLE
Implement cookie-based sessions and /me endpoint

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -1,0 +1,14 @@
+class Api::V1::SessionsController < ApplicationController
+  def show
+    if current_user
+      render json: UserSerializer.new(current_user).serializable_hash, status: :ok
+    else
+      render json: { error: "Not authenticated" }, status: :unauthorized
+    end
+  end
+
+  def destroy
+    log_out
+    head :no_content
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -4,6 +4,7 @@ class Api::V1::UsersController < ApplicationController
     user = User.new(user_params)
 
     if user.save
+      log_in(user)
       render json: UserSerializer.new(user).serializable_hash, status: :created
     else
       render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
@@ -13,6 +14,7 @@ class Api::V1::UsersController < ApplicationController
   def find
     user = User.find_by_email(params[:email])
     if user
+      log_in(user)
       render json: UserSerializer.new(user).serializable_hash, status: :ok
     else
       render json: { error: "User not found" }, status: :not_found

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,18 @@
 class ApplicationController < ActionController::API
+  include ActionController::Cookies
+
+  private
+
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id])
+  end
+
+  def log_in(user)
+    session[:user_id] = user.id
+  end
+
+  def log_out
+    session.delete(:user_id)
+    @current_user = nil
+  end
 end

--- a/client/src/context/UserContext.tsx
+++ b/client/src/context/UserContext.tsx
@@ -1,0 +1,133 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  ReactNode,
+} from 'react';
+
+type User = {
+  id: string;
+  first_name: string;
+  last_name: string;
+  email: string;
+  username: string;
+  birthday: string;
+  schedule_id: number | null;
+};
+
+type UserContextValue = {
+  user: User | null;
+  loading: boolean;
+  login: (email: string) => Promise<User>;
+  logout: () => Promise<void>;
+};
+
+const UserContext = createContext<UserContextValue | undefined>(undefined);
+
+async function fetchJson<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
+  const response = await fetch(input, {
+    ...init,
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init?.headers ?? {}),
+    },
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.json().catch(() => ({}));
+    const message = (errorBody as { error?: string }).error ?? response.statusText;
+    throw new Error(message || 'Request failed');
+  }
+
+  return response.json() as Promise<T>;
+}
+
+async function getCurrentUser(): Promise<User | null> {
+  try {
+    const payload = await fetchJson<{ data: { id: string; attributes: User } }>('http://localhost:3000/api/v1/me');
+    const { id, attributes } = payload.data;
+    return { ...attributes, id };
+  } catch (error) {
+    return null;
+  }
+}
+
+async function findUserByEmail(email: string): Promise<User> {
+  const payload = await fetchJson<{ data: { id: string; attributes: User } }>(
+    `http://localhost:3000/api/v1/users/find?email=${encodeURIComponent(email)}`
+  );
+
+  const { id, attributes } = payload.data;
+  return { ...attributes, id };
+}
+
+async function destroySession(): Promise<void> {
+  const response = await fetch('http://localhost:3000/api/v1/logout', {
+    method: 'DELETE',
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to logout');
+  }
+}
+
+export const UserProvider = ({ children }: { children: ReactNode }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    getCurrentUser()
+      .then((currentUser) => {
+        if (isMounted) {
+          setUser(currentUser);
+        }
+      })
+      .finally(() => {
+        if (isMounted) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const login = useCallback(async (email: string) => {
+    const foundUser = await findUserByEmail(email);
+    setUser(foundUser);
+    return foundUser;
+  }, []);
+
+  const logout = useCallback(async () => {
+    await destroySession();
+    setUser(null);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      user,
+      loading,
+      login,
+      logout,
+    }),
+    [user, loading, login, logout]
+  );
+
+  return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
+};
+
+export const useUser = (): UserContextValue => {
+  const context = useContext(UserContext);
+  if (!context) {
+    throw new Error('useUser must be used within a UserProvider');
+  }
+  return context;
+};

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,5 +40,9 @@ module CommunityGarden
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    # Enable cookie based sessions for API clients.
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::CookieStore, Rails.application.config.session_options
   end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -11,6 +11,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
 
     resource '*',
       headers: :any,
-      methods: [:get, :post, :patch, :put, :delete, :options, :head]
+      methods: [:get, :post, :patch, :put, :delete, :options, :head],
+      credentials: true
   end
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,5 +1,5 @@
 Rails.application.config.session_store :cookie_store,
-  key: "_happy_feet_session",
+  key: "happy_feet_music_festival",
   httponly: true,
   secure: Rails.env.production?,
   same_site: :lax

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,5 @@
+Rails.application.config.session_store :cookie_store,
+  key: "_happy_feet_session",
+  httponly: true,
+  secure: Rails.env.production?,
+  same_site: :lax

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,9 @@ Rails.application.routes.draw do
         resources :schedules, only: [:index, :create]
         resources :shows, only: [:index]
       end
+
+      get :me, to: "sessions#show"
+      delete :logout, to: "sessions#destroy"
     end
   end
 end

--- a/spec/requests/api/v1/sessions/me_spec.rb
+++ b/spec/requests/api/v1/sessions/me_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe 'Current session', type: :request do
+  describe 'GET /api/v1/me' do
+    it 'returns the current user when the session is valid' do
+      user = FactoryBot.create(:user)
+
+      # Simulate login via existing endpoint
+      get '/api/v1/users/find', params: { email: user.email }
+      expect(session[:user_id]).to eq(user.id)
+
+      get '/api/v1/me'
+
+      expect(response).to be_successful
+
+      json = JSON.parse(response.body, symbolize_names: true)[:data]
+      attributes = json[:attributes]
+
+      expect(json[:id]).to eq(user.id.to_s)
+      expect(attributes[:email]).to eq(user.email)
+    end
+
+    it 'returns unauthorized when there is no active session' do
+      get '/api/v1/me'
+
+      expect(response).to have_http_status(:unauthorized)
+
+      json = JSON.parse(response.body, symbolize_names: true)
+      expect(json[:error]).to eq('Not authenticated')
+    end
+  end
+end

--- a/spec/requests/api/v1/users/create_user_spec.rb
+++ b/spec/requests/api/v1/users/create_user_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'User Creation', type: :request do
         expect(attrs[:email]).to eq(user_attrs[:email])
         expect(attrs[:username]).to eq(user_attrs[:username])
         expect(attrs[:birthday]).to eq(user_attrs[:birthday].to_s)
+        expect(session[:user_id]).to eq(json[:id].to_i)
       end
     end
 

--- a/spec/requests/api/v1/users/finds_users_email_spec.rb
+++ b/spec/requests/api/v1/users/finds_users_email_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'Find User by Email', type: :request do
         expect(attributes[:last_name]).to eq(user.last_name)
         expect(attributes[:username]).to eq(user.username)
         expect(attributes[:birthday]).to eq(user.birthday.to_s)
+        expect(session[:user_id]).to eq(user.id)
       end
     end
 


### PR DESCRIPTION
## Summary
- enable cookie-backed API sessions and expose a /api/v1/me endpoint for checking authentication state
- update login and signup flows to establish the session and cover them with request specs
- add a React UserContext helper that rehydrates the user from /me and ensures authenticated fetch calls forward cookies

## Testing
- bundle exec rspec *(fails: bundler cannot install locked version because Ruby 3.4.4 does not satisfy required 3.2.2)*

------
https://chatgpt.com/codex/tasks/task_e_68e44152c89c832c96cc6aaca110a9b6