### PR TITLE
Fix session store setup for API-only application

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,7 +42,13 @@ module CommunityGarden
     config.api_only = true
 
     # Enable cookie based sessions for API clients.
+    config.session_store :cookie_store,
+                         key: "happy_feet_music_festival",
+                         httponly: true,
+                         secure: Rails.env.production?,
+                         same_site: :lax
+
     config.middleware.use ActionDispatch::Cookies
-    config.middleware.use ActionDispatch::Session::CookieStore, Rails.application.config.session_options
+    config.middleware.use ActionDispatch::Session::CookieStore, config.session_options
   end
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,5 +1,0 @@
-Rails.application.config.session_store :cookie_store,
-  key: "happy_feet_music_festival",
-  httponly: true,
-  secure: Rails.env.production?,
-  same_site: :lax


### PR DESCRIPTION
## Summary
- configure the cookie session store options directly in the application config so the API-only middleware can build correctly
- remove the redundant session store initializer now that the configuration lives alongside the middleware setup

## Testing
- bin/rails about *(fails: Ruby version 3.4.4, but Gemfile requires 3.2.2)*

------
https://chatgpt.com/codex/tasks/task_e_68e6d8f09b44832ca70f7eb7ecc97b29