### PR TITLE
Persist sessions with secure cookie

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::SessionsController < ApplicationController
-  def show
+  def me
     if current_user
       render json: UserSerializer.new(current_user).serializable_hash, status: :ok
     else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,11 +8,12 @@ class ApplicationController < ActionController::API
   end
 
   def log_in(user)
+    reset_session
     session[:user_id] = user.id
   end
 
   def log_out
-    session.delete(:user_id)
+    reset_session
     @current_user = nil
   end
 end

--- a/client/src/context/UserContext.tsx
+++ b/client/src/context/UserContext.tsx
@@ -8,6 +8,8 @@ import {
   ReactNode,
 } from 'react';
 
+const API_BASE_URL = 'http://localhost:3000/api/v1';
+
 type User = {
   id: string;
   first_name: string;
@@ -48,7 +50,7 @@ async function fetchJson<T>(input: RequestInfo, init?: RequestInit): Promise<T> 
 
 async function getCurrentUser(): Promise<User | null> {
   try {
-    const payload = await fetchJson<{ data: { id: string; attributes: User } }>('http://localhost:3000/api/v1/me');
+    const payload = await fetchJson<{ data: { id: string; attributes: User } }>(`${API_BASE_URL}/me`);
     const { id, attributes } = payload.data;
     return { ...attributes, id };
   } catch (error) {
@@ -58,7 +60,7 @@ async function getCurrentUser(): Promise<User | null> {
 
 async function findUserByEmail(email: string): Promise<User> {
   const payload = await fetchJson<{ data: { id: string; attributes: User } }>(
-    `http://localhost:3000/api/v1/users/find?email=${encodeURIComponent(email)}`
+    `${API_BASE_URL}/users/find?email=${encodeURIComponent(email)}`
   );
 
   const { id, attributes } = payload.data;
@@ -66,7 +68,7 @@ async function findUserByEmail(email: string): Promise<User> {
 }
 
 async function destroySession(): Promise<void> {
-  const response = await fetch('http://localhost:3000/api/v1/logout', {
+  const response = await fetch(`${API_BASE_URL}/logout`, {
     method: 'DELETE',
     credentials: 'include',
   });

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,13 +41,6 @@ module CommunityGarden
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
 
-    # Enable cookie based sessions for API clients.
-    config.session_store :cookie_store,
-                         key: "happy_feet_music_festival",
-                         httponly: true,
-                         secure: Rails.env.production?,
-                         same_site: :lax
-
     config.middleware.use ActionDispatch::Cookies
     config.middleware.use ActionDispatch::Session::CookieStore, config.session_options
   end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,5 @@
+Rails.application.config.session_store :cookie_store,
+                                       key: '_music_festival_session',
+                                       httponly: true,
+                                       secure: Rails.env.production?,
+                                       same_site: :lax

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
         resources :shows, only: [:index]
       end
 
-      get :me, to: "sessions#show"
+      get :me, to: "sessions#me"
       delete :logout, to: "sessions#destroy"
     end
   end


### PR DESCRIPTION
## Summary
- configure the Rails API to issue secure, HTTP-only session cookies for authentication
- expose `/api/v1/me` so the client can look up the current session user and rotate sessions on login/logout
- have the React user context rehydrate itself from `/api/v1/me` and share a single API base URL for authenticated requests

## Testing
- bundle exec rspec *(fails: command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eeed0a240c832ca4263b7c6974e0db