### PR TITLE
Update Fly release command to prepare database

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,5 +1,5 @@
-app = "your-app-name" # Replace with your Fly.io app name
-primary_region = "iad" # Or your preferred region
+app = "musicfestival"
+primary_region = "iad"
 
 [build]
   dockerfile = "Dockerfile"
@@ -8,4 +8,5 @@ primary_region = "iad" # Or your preferred region
   PORT = "8080"
 
 [deploy]
-  release_command = "/rails/bin/rails db:migrate"
+  # Use db:prepare so the first deploy can create the database automatically
+  release_command = "/rails/bin/rails db:prepare"


### PR DESCRIPTION
## Summary
- set the Fly app name in `fly.toml`
- switch the Fly release command to `rails db:prepare` so the first deploy can create the database automatically

## Testing
- not run (config change only)


------
https://chatgpt.com/codex/tasks/task_e_68fff7f94894832c8d06fc2ffa0d8205